### PR TITLE
Hooks & Actions

### DIFF
--- a/colorlib-coming-soon-and-maintenance-mode.php
+++ b/colorlib-coming-soon-and-maintenance-mode.php
@@ -77,7 +77,6 @@ function ccsm_add_settings_link( $actions, $plugin_file ) {
 
 /* Redirect code that checks if on WP login page */
 function ccsm_skip_redirect_on_login() {
-
 	global $pagenow;
 	if ( 'wp-login.php' == $pagenow ) {
 		return;
@@ -86,19 +85,35 @@ function ccsm_skip_redirect_on_login() {
 	}
 }
 
+function ccsm_skip_redirect($should_skip=false){
+	return $should_skip;
+}
+add_filter( 'ccsm_skip_redirect', 'ccsm_skip_redirect' );
+
+function ccsm_force_redirect($should_force=false){
+	return $should_force;
+}
+add_filter( 'ccsm_force_redirect', 'ccsm_force_redirect' );
+
+
 /* Coming Soon Redirect to Template */
 function ccsm_template_redirect() {
-
 	global $wp_customize;
 	$ccsm_options = get_option( 'ccsm_settings' );
 
+	// allow plugins & themes to control whether to force the check, regardless of any other settings
+	$force = apply_filters('ccsm_force_redirect', false);
+
 	//Checks for if user is logged in and CCSM is activated  OR if customizer is open on CCSM customization panel
-	if ( ! is_user_logged_in() && $ccsm_options['colorlib_coming_soon_activation'] == 1 || is_customize_preview() && isset( $_REQUEST['colorlib-coming-soon-customization'] ) ) {
-
-		$file = plugin_dir_path( __FILE__ ) . 'includes/colorlib-template.php'; //get path of our coming soon display page and redirecting
-		include( $file );
-
-		exit();
+	$activated = !is_user_logged_in() && $ccsm_options['colorlib_coming_soon_activation'] == 1 || is_customize_preview() && isset( $_REQUEST['colorlib-coming-soon-customization'] );
+	if ( $force || $activated ) {		
+		// allow plugins & themes to control whether to filter
+		$skip = apply_filters('ccsm_skip_redirect', false);
+		if( $force || !$skip ){
+			$file = plugin_dir_path( __FILE__ ) . 'includes/colorlib-template.php'; //get path of our coming soon display page and redirecting
+			include( $file );
+			exit();
+		}
 	}
 }
 

--- a/colorlib-coming-soon-and-maintenance-mode.php
+++ b/colorlib-coming-soon-and-maintenance-mode.php
@@ -104,10 +104,12 @@ function ccsm_template_redirect() {
 	// allow plugins & themes to control whether to force the check, regardless of any other settings
 	$force = apply_filters('ccsm_force_redirect', false);
 
-	//Checks for if user is logged in and CCSM is activated  OR if customizer is open on CCSM customization panel
+	// Checks for if user is logged in and CCSM is activated  OR if customizer is open on CCSM customization panel
 	$activated = !is_user_logged_in() && $ccsm_options['colorlib_coming_soon_activation'] == 1 || is_customize_preview() && isset( $_REQUEST['colorlib-coming-soon-customization'] );
-	if ( $force || $activated ) {		
-		// allow plugins & themes to control whether to filter
+
+	// If something "forced" it, or the default case was met, we might redirect
+	if ( $force || $activated ) {
+		// allow plugins & themes to skip the redirect (assuming force wasn't set)
 		$skip = apply_filters('ccsm_skip_redirect', false);
 		if( $force || !$skip ){
 			$file = plugin_dir_path( __FILE__ ) . 'includes/colorlib-template.php'; //get path of our coming soon display page and redirecting

--- a/templates/template_01/template_01.php
+++ b/templates/template_01/template_01.php
@@ -60,7 +60,10 @@ if ( ccsm_template_has_text_color() ) {
             <p class="m1-txt1 p-b-36" id="colorlib_coming_soon_page_heading">
 				<?php echo wp_kses_post( $ccsm_options['colorlib_coming_soon_page_heading'] ); ?>
             </p>
-			<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+			<?php 
+			    do_action('colorlib_coming_soon_before_forms'); 
+ 			    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+			?>
                 <form class="contact100-form validate-form"
                       action="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_url'] ); ?>" method="POST">
                     <div class="wrap-input100 m-b-10 validate-input"

--- a/templates/template_02/template_02.php
+++ b/templates/template_02/template_02.php
@@ -51,7 +51,10 @@ if ( ccsm_template_has_text_color() ) {
                 </div>
             </div>
 		<?php } ?>
-		<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+		<?php 
+		    do_action('colorlib_coming_soon_before_forms');
+ 		    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+		?>
             <form class="w-full flex-w flex-c-m validate-form"
                   action="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_url'] ); ?>" method="POST">
 

--- a/templates/template_03/template_03.php
+++ b/templates/template_03/template_03.php
@@ -53,7 +53,10 @@ if ( ccsm_template_has_text_color() ) {
                 </div>
             </div>
 		<?php } ?>
-		<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+		<?php 
+		    do_action('colorlib_coming_soon_before_forms'); 
+ 		    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+		?>
             <form class="flex-w flex-c-m contact100-form validate-form p-t-55" action="<?php echo esc_url($ccsm_options['colorlib_coming_soon_subscribe_form_url']); ?>" method="POST">
                 <div class="wrap-input100 validate-input where1" data-validate="<?php echo esc_attr__('Email is required: ex@abc.xyz','colorlib-coming-soon-maintenance'); ?>">
                     <input class="s1-txt2 placeholder0 input100" type="text" name="EMAIL" placeholder="<?php echo esc_attr__('Your Email','colorlib-coming-soon-maintenance'); ?>">

--- a/templates/template_04/template_04.php
+++ b/templates/template_04/template_04.php
@@ -39,7 +39,10 @@ $dates             = ccsm_counter_dates( $counter );
                     </div>
                 </div>
 			<?php } ?>
-			<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+			<?php 
+			    do_action('colorlib_coming_soon_before_forms'); 
+ 			    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+			?>
 
                 <button class="flex-c-m s1-txt2 size3 how-btn" data-toggle="modal" data-target="#subscribe"
                         id="colorlib_coming_soon_page_footer">
@@ -54,7 +57,10 @@ $dates             = ccsm_counter_dates( $counter );
 		</span>
 
     </div>
-<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+<?php 
+    do_action('colorlib_coming_soon_before_forms'); 
+     if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+?>
 
     <div class="modal fade" id="subscribe" tabindex="-1" role="dialog" data-backdrop="true">
         <div class="modal-dialog" role="document">

--- a/templates/template_05/template_05.php
+++ b/templates/template_05/template_05.php
@@ -40,7 +40,10 @@ $dates             = ccsm_counter_dates( $counter );
             <p class="txt-center l1-txt2 p-b-43 wsize2" id="colorlib_coming_soon_page_content">
 				<?php echo wp_kses_post( $ccsm_options['colorlib_coming_soon_page_content'] ); ?>
             </p>
-			<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+			<?php 
+			    do_action('colorlib_coming_soon_before_forms'); 
+ 			    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+			?>
                 <form class="flex-w flex-c-m w-full contact100-form validate-form"
                       action="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_url'] ); ?>" method="POST">
                     <div class="wrap-input100 validate-input where1"

--- a/templates/template_06/template_06.php
+++ b/templates/template_06/template_06.php
@@ -92,7 +92,10 @@ $dates             = ccsm_counter_dates( $counter );
                     <div class="cd100"></div> <?php } ?>
 
             </div>
-			<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+			<?php 
+			    do_action('colorlib_coming_soon_before_forms'); 
+ 			    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+			?>
                 <div class="bg0 wsize1 bor1 p-l-45 p-r-45 p-t-50 p-b-18 p-lr-15-sm">
                     <h3 class="l1-txt3 txt-center p-b-43">
 						<?php echo esc_html__( 'Newsletter', 'colorlib-coming-soon-maintenance' ); ?>

--- a/templates/template_07/template_07.php
+++ b/templates/template_07/template_07.php
@@ -83,7 +83,10 @@ $dates             = ccsm_counter_dates( $counter );
                 <p class="txt-center l1-txt1 p-b-60" id="colorlib_coming_soon_page_heading">
 					<?php echo wp_kses_post( $ccsm_options['colorlib_coming_soon_page_heading'] ); ?>
                 </p>
-				<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+				<?php 
+				    do_action('colorlib_coming_soon_before_forms'); 
+ 				    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+				?>
                     <form class="w-full flex-w flex-c-m validate-form"
                           action="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_url'] ); ?>" method="POST">
 

--- a/templates/template_08/template_08.php
+++ b/templates/template_08/template_08.php
@@ -48,7 +48,10 @@ $dates             = ccsm_counter_dates( $counter );
                     </div>
                 </div>
 			<?php } ?>
-			<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+			<?php 
+			    do_action('colorlib_coming_soon_before_forms'); 
+ 			    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+			?>
                 <form class="flex-w flex-c-m contact100-form validate-form p-t-70"
                       action="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_url'] ); ?>" method="POST">
                     <div class="wrap-input100 validate-input where1"

--- a/templates/template_09/template_09.php
+++ b/templates/template_09/template_09.php
@@ -32,6 +32,7 @@ if ( ccsm_template_has_text_color() ) {
 				}
 				?>
             </div>
+            <? do_action('colorlib_coming_soon_before_forms'); /* This likely needs to be something different? */ ?>
 			<?php if ( isset( $ccsm_options['colorlib_coming_soon_subscribe_form_other'] ) && '' == $ccsm_options['colorlib_coming_soon_subscribe_form_other'] ) { ?>
                 <div class="flex-w m-t-10 m-b-10">
                     <a href="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_other'] ); ?>"

--- a/templates/template_10/template_10.php
+++ b/templates/template_10/template_10.php
@@ -49,7 +49,10 @@ if ( ccsm_template_has_text_color() ) {
                 <p class="m2-txt1 respon6" id="colorlib_coming_soon_page_content">
 					<?php echo wp_kses_post( $ccsm_options['colorlib_coming_soon_page_content'] ); ?>
                 </p>
-				<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+				<?php 
+				    do_action('colorlib_coming_soon_before_forms'); 
+ 				    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+				?>
                     <form class="contact100-form validate-form p-t-55 w-full"
                           action="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_url'] ); ?>" method="POST">
                         <div class="wrap-input100 validate-input m-lr-auto-lg"

--- a/templates/template_12/template_12.php
+++ b/templates/template_12/template_12.php
@@ -28,7 +28,10 @@ $dates             = ccsm_counter_dates( $counter );
                     <p class="m2-txt1 p-b-46" id="colorlib_coming_soon_page_content">
 						<?php echo wp_kses_post( $ccsm_options['colorlib_coming_soon_page_content'] ); ?>
                     </p>
-					<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+					<?php 
+					    do_action('colorlib_coming_soon_before_forms'); 
+ 					    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+					?>
                         <form class="contact100-form validate-form m-t-10 m-b-10"
                               action="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_url'] ); ?>" method="POST">
                             <div class="wrap-input100 validate-input m-lr-auto-lg"

--- a/templates/template_13/template_13.php
+++ b/templates/template_13/template_13.php
@@ -137,7 +137,10 @@ if ( ccsm_template_has_text_color() ) {
 				?>
 
             </div>
-			<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+			<?php 
+			    do_action('colorlib_coming_soon_before_forms'); 
+ 			    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+			?>
                 <form class="contact100-form validate-form m-t-10 m-b-10"
                       action="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_url'] ); ?>" method="POST">
                     <div class="wrap-input100 validate-input m-lr-auto-lg"

--- a/templates/template_14/template_14.php
+++ b/templates/template_14/template_14.php
@@ -31,7 +31,10 @@ $dates             = ccsm_counter_dates( $counter );
                 <p class="m2-txt1 p-b-46" id="colorlib_coming_soon_page_content">
 					<?php echo wp_kses_post( $ccsm_options['colorlib_coming_soon_page_content'] ); ?>
                 </p>
-				<?php if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) { ?>
+				<?php 
+				    do_action('colorlib_coming_soon_before_forms'); 
+ 				    if ( $ccsm_options['colorlib_coming_soon_subscribe'] != '1' ) {  
+				?>
                     <form class="contact100-form validate-form m-t-10 m-b-10"
                           action="<?php echo esc_url( $ccsm_options['colorlib_coming_soon_subscribe_form_url'] ); ?>" method="POST">
                         <div class="wrap-input100 validate-input m-lr-auto-lg"


### PR DESCRIPTION
This PR adds two hooks to allow greater customization of the plugin. I've tested them fairly well for my use-case, but we're only using template 1 so it'd be worth playing around with on the others. 

We've added 2 filters and 1 action, though more actions at various cut points (wrapping various form elements) would be lovely!

# Force / Skip
Filters for either `forcing` or `skipping` the redirect. If both are specified, `force` will take priority over `skip` – which was useful when we always wanted our homepage to show this no-matter-what. 

Filters created: 
- `ccsm_force_redirect`
- `ccsm_skip_redirect`

# Actions
We wanted to only show button that lead to a page we whitelisted (via `skip` above) where the contact form normally was. The end result turned out pretty nice (will attach screenshot) 

Actions created:
- `colorlib_coming_soon_before_forms`


# Example usage
```
class ColorLibOverrides {

  function init(){
    add_filter( 'ccsm_skip_redirect', [$this, 'check_skip_redirect'] ); 
    add_filter( 'ccsm_force_redirect', [$this, 'check_force_redirect'] ); 
    add_action('colorlib_coming_soon_before_forms', [$this, 'color_lib_button']);
  }

  function check_skip_redirect($should_skip) {	
    global $post;
    $end = end(explode('/', get_page_template()));
    $status = $post->post_status;

    if( $status === 'publish' ){
      if( $end === 'page-custom.php' ){
        return $should_skip || true;
      }
    }
    return $should_skip;
  }

  // always show the homepage
  function check_force_redirect($should_force) {
    return is_home() || $should_force;
  }

  function color_lib_button(){
    echo '<a class="flex-c-m s2-txt2 size4 bg1 bor1 hov1 trans-04" href="/lets-do-this">Let\'s do this</a>';
  }
}

(new ColorLibOverrides())->init();
```